### PR TITLE
Search IMDB & NYTReviews using keyword and GET Streaming Services and Reviews

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -1,0 +1,38 @@
+var imdbApiKey = "k_8oixkc80";
+
+var getIMDBMedia = function (title) {
+    var imdbQueryUrl = "https://imdb-api.com/en/API/SearchAll/" + imdbApiKey + "/" + title;
+
+    fetch(imdbQueryUrl).then(function (response) {
+        if (response.ok) {
+            response.json().then(function (data) {
+                console.log("IMDB:", data);
+                getStreamAvailability(data.results[0].id);
+            });
+        } else {
+            alert("Error: Title not found");
+        }
+    });
+};
+
+getIMDBMedia("The Big Lebowski");
+
+//Streaming Availability API
+var getStreamAvailability = function (mediaId) {
+    fetch("https://streaming-availability.p.rapidapi.com/get/basic?country=us&imdb_id=" + mediaId + "&output_language=en", {
+	"method": "GET",
+	"headers": {
+		"x-rapidapi-host": "streaming-availability.p.rapidapi.com",
+		"x-rapidapi-key": "21f375a3cfmsh4f8395beb749419p1aaee6jsn187734a6f501"
+	}
+})
+.then(response => {
+    response.json().then(function (data) {
+        console.log("streamAvail:", data);
+    })
+})
+.catch(err => {
+	console.error(err);
+});
+
+}

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -29,6 +29,15 @@ var getStreamAvailability = function (mediaId) {
 .then(response => {
     response.json().then(function (data) {
         console.log("streamAvail:", data);
+        var banner = data.posterURLs.original;
+        var desc = data.overview;
+        var cast = data.cast;
+        var strmSrvc = data.streamingInfo;
+
+        console.log("banner:", banner);
+        console.log("Description:", desc);
+        console.log("Cast:", cast);
+        console.log("Streaming Services:", strmSrvc);
     })
 })
 .catch(err => {

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -1,4 +1,5 @@
-var imdbApiKey = "k_8oixkc80";
+const imdbApiKey = "k_8oixkc80";
+const nytReviewsApiKey = "1CtMayWncOQbFJuoqvGVAcHGbcd644Hj";
 
 // Get Series/Movie Title from IMDB and ID
 var getIMDBMedia = function (title) {
@@ -9,6 +10,7 @@ var getIMDBMedia = function (title) {
             response.json().then(function (data) {
                 console.log("IMDB:", data);
                 getStreamAvailability(data.results[0].id);
+                getNytReviews(title);
             });
         } else {
             alert("Error: Title not found");
@@ -45,3 +47,18 @@ var getStreamAvailability = function (mediaId) {
             console.error(err);
         });
 }
+
+// API Call to NYTimes Reviews
+var getNytReviews = function (title) {
+    var nytReviewQueryUrl = "https://api.nytimes.com/svc/movies/v2/reviews/search.json?query=" + title + "&api-key=" + nytReviewsApiKey;
+
+    fetch(nytReviewQueryUrl).then(function (response) {
+        if (response.ok) {
+            response.json().then(function (data) {
+                console.log(data);
+            });
+        } else {
+            alert("Error: Review not found");
+        }
+    });
+};

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -1,5 +1,6 @@
 var imdbApiKey = "k_8oixkc80";
 
+// Get Series/Movie Title from IMDB and ID
 var getIMDBMedia = function (title) {
     var imdbQueryUrl = "https://imdb-api.com/en/API/SearchAll/" + imdbApiKey + "/" + title;
 
@@ -17,31 +18,30 @@ var getIMDBMedia = function (title) {
 
 getIMDBMedia("The Big Lebowski");
 
-//Streaming Availability API
+//Function to use IMDB ID to locate Streaming Services
 var getStreamAvailability = function (mediaId) {
     fetch("https://streaming-availability.p.rapidapi.com/get/basic?country=us&imdb_id=" + mediaId + "&output_language=en", {
-	"method": "GET",
-	"headers": {
-		"x-rapidapi-host": "streaming-availability.p.rapidapi.com",
-		"x-rapidapi-key": "21f375a3cfmsh4f8395beb749419p1aaee6jsn187734a6f501"
-	}
-})
-.then(response => {
-    response.json().then(function (data) {
-        console.log("streamAvail:", data);
-        var banner = data.posterURLs.original;
-        var desc = data.overview;
-        var cast = data.cast;
-        var strmSrvc = data.streamingInfo;
-
-        console.log("banner:", banner);
-        console.log("Description:", desc);
-        console.log("Cast:", cast);
-        console.log("Streaming Services:", strmSrvc);
+        "method": "GET",
+        "headers": {
+            "x-rapidapi-host": "streaming-availability.p.rapidapi.com",
+            "x-rapidapi-key": "21f375a3cfmsh4f8395beb749419p1aaee6jsn187734a6f501"
+        }
     })
-})
-.catch(err => {
-	console.error(err);
-});
+        .then(response => {
+            response.json().then(function (data) {
+                console.log("streamAvail:", data);
+                var banner = data.posterURLs.original;
+                var desc = data.overview;
+                var cast = data.cast;
+                var strmSrvc = data.streamingInfo;
 
+                console.log("banner:", banner);
+                console.log("Description:", desc);
+                console.log("Cast:", cast);
+                console.log("Streaming Services:", strmSrvc);
+            })
+        })
+        .catch(err => {
+            console.error(err);
+        });
 }

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+</head>
+<body>
+    <script src="assets/js/scripts.js"></script>
+</body>
+</html>


### PR DESCRIPTION
**Tickets:** 
https://github.com/emdok/bang-imdb/issues/4
https://github.com/emdok/bang-imdb/issues/5

1. In this PR I have used passed a title through the `getIMDBMedia()` function to get the IMDB ID. Then I take the IMDB ID and pass it through the function `getStreamAvailability()` to get the streaming availability of the title. I used the following API's to make this work:
https://rapidapi.com/movie-of-the-night-movie-of-the-night-default/api/streaming-availability
https://imdb-api.com/api/#SearchAll-header
The idea here is that once the search bar is created I can create a variable for the search term to pass to IMDB.

2. I have also included the API Call to NYTimes Reviews to get reviews based on the user Search Term