### PR TITLE
Remove Recent Search History from SearchTermHandler

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -145,8 +145,6 @@ var searchTermHandler = function (keyword) {
 
     userSearchHistory.push(keyword);
     localStorage.setItem("search term", JSON.stringify(userSearchHistory));
-    recentSearchHistory();
-
     mediaGridEl.innerHTML = "";
     var results = getIMDBMedia(keyword);
     console.log(results);


### PR DESCRIPTION
Removed RecentSearchHistory from SearchTermHandler so that when a user searched for new shows, recent searches didn't also display.