### PR TITLE
Feature/code cleanup round2

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -110,6 +110,7 @@ function strmServiceTitle(str) {
     return title[1];
 }
 
+// Function to check Local Storage for any recent user searches and add to array
 var recentSearchHistory = function () {
 
     if (localStorage.getItem("search term")) {
@@ -152,6 +153,7 @@ navHome.addEventListener("click", function () {
     getDefaultIMDBMedia();    
 });
 
+// Function to grab Most Popular Movies from IMDB
 var getMovieIMDBMedia = function () {
     var imdbQueryUrl = "https://imdb-api.com/en/API/MostPopularMovies/" + imdbApiKey
     
@@ -183,6 +185,7 @@ navMovies.addEventListener("click", function () {
     
 });
 
+// Function to get Most Popular TV Shows from IMDB
 var getTvShowIMDBMedia = function () {
     var imdbQueryUrl = "https://imdb-api.com/en/API/MostPopularTVs/" + imdbApiKey;
 
@@ -212,6 +215,7 @@ navTvShows.addEventListener("click", function () {
     getTvShowIMDBMedia(); 
 });
 
+// Function to call top rated media on IMDB
 var getTopRatedIMDBMedia = function () {
     var imdbQueryUrl = "https://imdb-api.com/API/AdvancedSearch/" + imdbApiKey + "?title_type=feature,tv_movie,tv_series,tv_episode,documentary&groups=top_100&countries=us&languages=en";
 
@@ -242,6 +246,7 @@ navTopRated.addEventListener("click", function () {
     getTopRatedIMDBMedia();
 });
 
+// Function to create media cards per API Call
 function cardMaker(title, banner, streamLink, streamName) {
 
     mediaGridEl.innerHTML += `
@@ -253,7 +258,7 @@ function cardMaker(title, banner, streamLink, streamName) {
       <img src="${banner}" width="100%" alt="">
     </div>
     <div class="mdl-card__actions mdl-card--border">
-      <a href="${streamLink}" class="card-button mdl-button mdl-js-button mdl-js-ripple-effect">
+      <a href="${streamLink}" target="_blank" class="card-button mdl-button mdl-js-button mdl-js-ripple-effect">
         ${streamName}
       </a>
     </div>

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -1,9 +1,9 @@
 const imdbApiKey = "k_8oixkc80";
-const nytReviewsApiKey = "1CtMayWncOQbFJuoqvGVAcHGbcd644Hj";
 const searchQuery = document.querySelector('#fixed-header-drawer-exp');
 var mediaGridEl = document.querySelector("#media-grid");
 var userSearchHistory = [];
 
+// Function to sleep to prevent 429 errors on API Calls
 function sleep(milliseconds) {
     const date = Date.now();
     let currentDate = null;
@@ -49,7 +49,6 @@ var getIMDBMedia = function (title) {
                         console.log('error in getIMDBMedia is: ', err)
                     })
                 }
-                getNytReviews(title);
             });
         } else {
             alert("Error: Title not found");
@@ -111,21 +110,6 @@ function strmServiceTitle(str) {
     return title[1];
 }
 
-// API Call to NYTimes Reviews
-var getNytReviews = function (title) {
-    var nytReviewQueryUrl = "https://api.nytimes.com/svc/movies/v2/reviews/search.json?query=" + title + "&api-key=" + nytReviewsApiKey;
-
-    fetch(nytReviewQueryUrl).then(function (response) {
-        if (response.ok) {
-            response.json().then(function (data) {
-                console.log(data);
-            });
-        } else {
-            console.log("Error: Review not found");
-        }
-    });
-};
-
 var recentSearchHistory = function () {
 
     if (localStorage.getItem("search term")) {
@@ -148,7 +132,6 @@ var searchTermHandler = function (keyword) {
     mediaGridEl.innerHTML = "";
     var results = getIMDBMedia(keyword);
     console.log(results);
-
 }
 
 // listen for the user to press return to capture search term
@@ -193,10 +176,9 @@ var getMovieIMDBMedia = function () {
 var navMovies = document.querySelector("#movies");
 navMovies.addEventListener("click", function () {
     event.preventDefault()
-
     console.log("movieClicked");
+
     mediaGridEl.innerHTML = "";
-    
     getMovieIMDBMedia();
     
 });
@@ -227,9 +209,7 @@ navTvShows.addEventListener("click", function () {
     event.preventDefault();
 
     mediaGridEl.innerHTML = "";
-
-    getTvShowIMDBMedia();
-   
+    getTvShowIMDBMedia(); 
 });
 
 var getTopRatedIMDBMedia = function () {

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -1,6 +1,10 @@
 const imdbApiKey = "k_8oixkc80";
 const searchQuery = document.querySelector('#fixed-header-drawer-exp');
 var mediaGridEl = document.querySelector("#media-grid");
+var navHome = document.querySelector("#home");
+var navMovies = document.querySelector("#movies");
+var navTvShows = document.querySelector("#tv-shows");
+var navTopRated = document.querySelector("#top-rated");
 var userSearchHistory = [];
 
 // Function to sleep to prevent 429 errors on API Calls
@@ -83,11 +87,7 @@ function getStreamAvailability(mediaId) {
                     var service = Object.values(streaming)[0];
                     var service2 = Object.values(service)[0];
                     var serviceLink = service2.link;
-                    console.log(serviceLink);
                     var serviceName = strmServiceTitle(serviceLink);
-                    console.log(serviceName);
-                    console.log(banner);
-                    console.log(title);
 
                     cardMaker(title, banner, serviceLink, serviceName);
 
@@ -116,42 +116,13 @@ var recentSearchHistory = function () {
     if (localStorage.getItem("search term")) {
         userSearchHistory = JSON.parse(localStorage.getItem("search term"));
 
-        for (var i = 0; i < userSearchHistory.length; i++) {
+        for (var i = 0; i < 5; i++) {
             getIMDBMedia(userSearchHistory[i]);
         };
     }
 };
 
 recentSearchHistory();
-
-// Action to take when user has pressed Return, runs getIMDBMedia function on user searchTerms
-var searchTermHandler = function (keyword) {
-    event.preventDefault();
-
-    userSearchHistory.push(keyword);
-    localStorage.setItem("search term", JSON.stringify(userSearchHistory));
-    mediaGridEl.innerHTML = "";
-    var results = getIMDBMedia(keyword);
-    console.log(results);
-}
-
-// listen for the user to press return to capture search term
-searchQuery.addEventListener('keyup', function (event) {
-
-    if (event.keyCode === 13) {
-        var searchTerms = this.value;
-        searchTermHandler(searchTerms);
-    }
-});
-
-// on click refresh homepage with default view
-var navHome = document.querySelector("#home");
-navHome.addEventListener("click", function () {
-    event.preventDefault();
-    mediaGridEl.innerHTML = "";
-    
-    getDefaultIMDBMedia();    
-});
 
 // Function to grab Most Popular Movies from IMDB
 var getMovieIMDBMedia = function () {
@@ -161,7 +132,6 @@ var getMovieIMDBMedia = function () {
         if (response.ok) {
             response.json().then(function (data) {
                 var array = data.items;
-                console.log(data);
                 for (let i = 0; i < 50; i++) {
                     sleep(150);
                     var media = array[i].id;
@@ -173,17 +143,6 @@ var getMovieIMDBMedia = function () {
         }
     });
 };
-
-// on click refresh homepage, display only movies
-var navMovies = document.querySelector("#movies");
-navMovies.addEventListener("click", function () {
-    event.preventDefault()
-    console.log("movieClicked");
-
-    mediaGridEl.innerHTML = "";
-    getMovieIMDBMedia();
-    
-});
 
 // Function to get Most Popular TV Shows from IMDB
 var getTvShowIMDBMedia = function () {
@@ -193,7 +152,6 @@ var getTvShowIMDBMedia = function () {
         if (response.ok) {
             response.json().then(function (data) {
                 var array = data.items;
-                console.log(data);
                 for (let i = 0; i < 50; i++) {
                     sleep(150);
                     var media = array[i].id;
@@ -205,15 +163,6 @@ var getTvShowIMDBMedia = function () {
         }
     });
 };
-
-// on click refresh homepage, display only tv shows
-var navTvShows = document.querySelector("#tv-shows");
-navTvShows.addEventListener("click", function () {
-    event.preventDefault();
-
-    mediaGridEl.innerHTML = "";
-    getTvShowIMDBMedia(); 
-});
 
 // Function to call top rated media on IMDB
 var getTopRatedIMDBMedia = function () {
@@ -223,7 +172,6 @@ var getTopRatedIMDBMedia = function () {
         if (response.ok) {
             response.json().then(function (data) {
                 var array = data.results;
-                console.log(data);
                 for (let i = 0; i < 50; i++) {
                     sleep(150);
                     var media = array[i].id;
@@ -235,16 +183,6 @@ var getTopRatedIMDBMedia = function () {
         }
     });
 };
-
-// on click refresh page, display new and popular results
-var navTopRated = document.querySelector("#top-rated");
-
-navTopRated.addEventListener("click", function () {
-    event.preventDefault();
-
-    mediaGridEl.innerHTML = "";
-    getTopRatedIMDBMedia();
-});
 
 // Function to create media cards per API Call
 function cardMaker(title, banner, streamLink, streamName) {
@@ -265,3 +203,55 @@ function cardMaker(title, banner, streamLink, streamName) {
   </div>
     `
 };
+
+// Action to take when user has pressed Return, runs getIMDBMedia function on user searchTerms
+var searchTermHandler = function (keyword) {
+    event.preventDefault();
+
+    userSearchHistory.push(keyword);
+    localStorage.setItem("search term", JSON.stringify(userSearchHistory));
+    mediaGridEl.innerHTML = "";
+    getIMDBMedia(keyword);
+}
+
+// listen for the user to press return to capture search term
+searchQuery.addEventListener('keyup', function (event) {
+
+    if (event.keyCode === 13) {
+        var searchTerms = this.value;
+        searchTermHandler(searchTerms);
+    }
+});
+
+// on click refresh homepage with default view
+navHome.addEventListener("click", function () {
+    event.preventDefault();
+
+    mediaGridEl.innerHTML = "";
+    getDefaultIMDBMedia();    
+});
+
+// on click refresh homepage, display only movies
+navMovies.addEventListener("click", function () {
+    event.preventDefault()
+    console.log("movieClicked");
+
+    mediaGridEl.innerHTML = "";
+    getMovieIMDBMedia();
+});
+
+// on click refresh homepage, display only tv shows
+navTvShows.addEventListener("click", function () {
+    event.preventDefault();
+
+    mediaGridEl.innerHTML = "";
+    getTvShowIMDBMedia(); 
+});
+
+// on click refresh page, display new and popular results
+navTopRated.addEventListener("click", function () {
+    event.preventDefault();
+
+    mediaGridEl.innerHTML = "";
+    getTopRatedIMDBMedia();
+});


### PR DESCRIPTION
This remove the NYTimes Function
This cleans up unnecessary Console.logs
This Places Global Variables and Query Selectors at top
Functions in the Middle
Event Listeners at the bottom